### PR TITLE
fix: improve RAG pipeline reliability — book matching, null response handling, and configurable parameters

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,6 +99,16 @@ DEEPSEEK_API_KEY=
 # TOP_K_SEARCHING=10     # For "searching_for_information" intent
 # TOP_K_DEFAULT=6        # For all other intents
 
+# Search weights per intent (dense vs sparse, must sum to 1.0)
+# SEARCH_WEIGHT_QA_DENSE=0.6
+# SEARCH_WEIGHT_QA_SPARSE=0.4
+# SEARCH_WEIGHT_SUMMARIZATION_DENSE=0.7
+# SEARCH_WEIGHT_SUMMARIZATION_SPARSE=0.3
+# SEARCH_WEIGHT_CODING_DENSE=0.4
+# SEARCH_WEIGHT_CODING_SPARSE=0.6
+# SEARCH_WEIGHT_SEARCHING_DENSE=0.5
+# SEARCH_WEIGHT_SEARCHING_SPARSE=0.5
+
 # ===========================================
 # Project Subject Configuration
 # ===========================================

--- a/.env.example
+++ b/.env.example
@@ -95,6 +95,10 @@ DEEPSEEK_API_KEY=
 # Increase if using reasoning models (e.g., gpt-5-nano) that consume tokens for thinking
 # LLM_MAX_TOKENS=16384
 
+# Number of retrieval chunks per search query
+# TOP_K_SEARCHING=10     # For "searching_for_information" intent
+# TOP_K_DEFAULT=6        # For all other intents
+
 # ===========================================
 # Project Subject Configuration
 # ===========================================

--- a/.env.example
+++ b/.env.example
@@ -91,6 +91,10 @@ DEEPSEEK_API_KEY=
 # This should be a fast, cheap model since it runs on every query before the main LLM
 # QUERY_ENHANCEMENT_MODEL=gpt-5-nano
 
+# Maximum completion tokens for LLM responses (includes reasoning + output)
+# Increase if using reasoning models (e.g., gpt-5-nano) that consume tokens for thinking
+# LLM_MAX_TOKENS=16384
+
 # ===========================================
 # Project Subject Configuration
 # ===========================================

--- a/services/api-gateway/app/config.py
+++ b/services/api-gateway/app/config.py
@@ -76,6 +76,16 @@ class Settings(BaseSettings):
     top_k_searching: int = int(os.getenv("TOP_K_SEARCHING", "10"))
     top_k_default: int = int(os.getenv("TOP_K_DEFAULT", "6"))
 
+    # Search weights per intent (dense vs sparse)
+    search_weight_qa_dense: float = float(os.getenv("SEARCH_WEIGHT_QA_DENSE", "0.6"))
+    search_weight_qa_sparse: float = float(os.getenv("SEARCH_WEIGHT_QA_SPARSE", "0.4"))
+    search_weight_summarization_dense: float = float(os.getenv("SEARCH_WEIGHT_SUMMARIZATION_DENSE", "0.7"))
+    search_weight_summarization_sparse: float = float(os.getenv("SEARCH_WEIGHT_SUMMARIZATION_SPARSE", "0.3"))
+    search_weight_coding_dense: float = float(os.getenv("SEARCH_WEIGHT_CODING_DENSE", "0.4"))
+    search_weight_coding_sparse: float = float(os.getenv("SEARCH_WEIGHT_CODING_SPARSE", "0.6"))
+    search_weight_searching_dense: float = float(os.getenv("SEARCH_WEIGHT_SEARCHING_DENSE", "0.5"))
+    search_weight_searching_sparse: float = float(os.getenv("SEARCH_WEIGHT_SEARCHING_SPARSE", "0.5"))
+
     # Default subject for new sessions
     default_subject: str = os.getenv("DEFAULT_SUBJECT", "Machine Learning")
 

--- a/services/api-gateway/app/config.py
+++ b/services/api-gateway/app/config.py
@@ -72,6 +72,10 @@ class Settings(BaseSettings):
     # Maximum completion tokens for LLM responses (includes reasoning + output)
     llm_max_tokens: int = int(os.getenv("LLM_MAX_TOKENS", "16384"))
 
+    # Top-K retrieval results per intent
+    top_k_searching: int = int(os.getenv("TOP_K_SEARCHING", "10"))
+    top_k_default: int = int(os.getenv("TOP_K_DEFAULT", "6"))
+
     # Default subject for new sessions
     default_subject: str = os.getenv("DEFAULT_SUBJECT", "Machine Learning")
 

--- a/services/api-gateway/app/config.py
+++ b/services/api-gateway/app/config.py
@@ -69,6 +69,9 @@ class Settings(BaseSettings):
     # Model for query enhancement (fast and cheap, runs on every query)
     query_enhancement_model: str = os.getenv("QUERY_ENHANCEMENT_MODEL", "gpt-5-nano")
 
+    # Maximum completion tokens for LLM responses (includes reasoning + output)
+    llm_max_tokens: int = int(os.getenv("LLM_MAX_TOKENS", "16384"))
+
     # Default subject for new sessions
     default_subject: str = os.getenv("DEFAULT_SUBJECT", "Machine Learning")
 

--- a/services/api-gateway/app/services/llm_service.py
+++ b/services/api-gateway/app/services/llm_service.py
@@ -95,9 +95,16 @@ class LLMService:
                 messages=messages,
                 max_completion_tokens=max_tokens,
             )
+            content = response.choices[0].message.content
+            if not content:
+                logger.warning(
+                    f"OpenAI returned empty content: model={model}, "
+                    f"finish_reason={response.choices[0].finish_reason}, "
+                    f"usage={response.usage}"
+                )
             usage = response.usage
             return {
-                "text": response.choices[0].message.content,
+                "text": content or "",
                 "total_tokens": usage.total_tokens if usage else None,
                 "prompt_tokens": usage.prompt_tokens if usage else None,
                 "completion_tokens": usage.completion_tokens if usage else None,
@@ -136,9 +143,16 @@ class LLMService:
                 messages=user_messages,
                 temperature=temperature
             )
+            content = response.content[0].text if response.content else None
+            if not content:
+                logger.warning(
+                    f"Anthropic returned empty content: model={model}, "
+                    f"stop_reason={response.stop_reason}, "
+                    f"usage={response.usage}"
+                )
             usage = response.usage
             return {
-                "text": response.content[0].text,
+                "text": content or "",
                 "total_tokens": (usage.input_tokens + usage.output_tokens) if usage else None,
                 "prompt_tokens": usage.input_tokens if usage else None,
                 "completion_tokens": usage.output_tokens if usage else None,
@@ -173,9 +187,16 @@ class LLMService:
                 temperature=temperature,
                 max_tokens=max_tokens
             )
+            content = response.choices[0].message.content
+            if not content:
+                logger.warning(
+                    f"DeepSeek returned empty content: model={model}, "
+                    f"finish_reason={response.choices[0].finish_reason}, "
+                    f"usage={response.usage}"
+                )
             usage = response.usage
             return {
-                "text": response.choices[0].message.content,
+                "text": content or "",
                 "total_tokens": usage.total_tokens if usage else None,
                 "prompt_tokens": usage.prompt_tokens if usage else None,
                 "completion_tokens": usage.completion_tokens if usage else None,

--- a/services/api-gateway/app/services/llm_service.py
+++ b/services/api-gateway/app/services/llm_service.py
@@ -50,7 +50,7 @@ class LLMService:
         messages: List[Dict[str, str]],
         model: Optional[str] = None,
         temperature: float = 0.7,
-        max_tokens: int = 4096
+        max_tokens: int = settings.llm_max_tokens
     ) -> Dict[str, Any]:
         """
         Generate a response using the specified model.

--- a/services/api-gateway/app/services/prompt_engineering.py
+++ b/services/api-gateway/app/services/prompt_engineering.py
@@ -177,7 +177,7 @@ Guidelines for search queries:
 - The search queries should all be focused on the same topic, but they should be different.
 - It is ok to use similar queries on different retrieval sentences, this will help to find the information in the books.
 - If a specific book is mentioned in the query using the format <Book>name_of_the_book</Book>, target your search queries to that book by setting book="name_of_the_book".
-- The book name should be written exactly as it is written in the tag <Book>name_of_the_book</Book>, do not ommit any part of the name, and do not add any part to the name.
+- The book name should be written exactly as it is written in the tag <Book>name_of_the_book</Book>, do not omit any part of the name, and do not add any part to the name.
 - If no specific book is mentioned or if the search should be performed across all available resources, use book="all".
 - Focus only on search term generation. Do not provide explanations or answers.
 - The subject of the conversation is {subject}.

--- a/services/api-gateway/app/services/prompt_engineering.py
+++ b/services/api-gateway/app/services/prompt_engineering.py
@@ -177,6 +177,7 @@ Guidelines for search queries:
 - The search queries should all be focused on the same topic, but they should be different.
 - It is ok to use similar queries on different retrieval sentences, this will help to find the information in the books.
 - If a specific book is mentioned in the query using the format <Book>name_of_the_book</Book>, target your search queries to that book by setting book="name_of_the_book".
+- The book name should be written exactly as it is written in the tag <Book>name_of_the_book</Book>, do not ommit any part of the name, and do not add any part to the name.
 - If no specific book is mentioned or if the search should be performed across all available resources, use book="all".
 - Focus only on search term generation. Do not provide explanations or answers.
 - The subject of the conversation is {subject}.

--- a/services/api-gateway/app/services/rag_orchestrator.py
+++ b/services/api-gateway/app/services/rag_orchestrator.py
@@ -193,7 +193,7 @@ class RAGOrchestrator:
         intent = intent_result.get("intent", "question_answering")
 
         # Adjust top_k based on intent
-        top_k = 12 if intent == "searching_for_information" else 6
+        top_k = settings.top_k_searching if intent == "searching_for_information" else settings.top_k_default
 
         # Wait for enhanced queries
         enhanced_queries = await enhanced_queries_task

--- a/services/api-gateway/app/services/search_service.py
+++ b/services/api-gateway/app/services/search_service.py
@@ -9,15 +9,16 @@ import logging
 
 from app.clients.qdrant_client import QdrantManager
 from app.clients.embedding_client import EmbeddingClient
+from app.config import settings
 
 logger = logging.getLogger(__name__)
 
-# Search weights based on intent
+# Search weights based on intent (configurable via env vars)
 SEARCH_WEIGHTS = {
-    "question_answering": {"dense": 0.6, "sparse": 0.4},
-    "summarization": {"dense": 0.7, "sparse": 0.3},
-    "coding": {"dense": 0.4, "sparse": 0.6},
-    "searching_for_information": {"dense": 0.5, "sparse": 0.5},
+    "question_answering": {"dense": settings.search_weight_qa_dense, "sparse": settings.search_weight_qa_sparse},
+    "summarization": {"dense": settings.search_weight_summarization_dense, "sparse": settings.search_weight_summarization_sparse},
+    "coding": {"dense": settings.search_weight_coding_dense, "sparse": settings.search_weight_coding_sparse},
+    "searching_for_information": {"dense": settings.search_weight_searching_dense, "sparse": settings.search_weight_searching_sparse},
 }
 
 


### PR DESCRIPTION
## Description
- Adds a fuzzy matching layer for book names in the query enhancement pipeline using `difflib.SequenceMatcher`
- When the LLM generates retrieval queries with a book name that doesn't exactly match what's in Qdrant, the system now finds the closest match above a 0.6 similarity threshold, or falls back to searching all books
- Adds info/warning logging when book names are corrected or unmatched
- Instructs the query enhancement LLM to use exact book names from `<Book>` tags
- Guards against null content from LLM API responses (OpenAI/Anthropic/DeepSeek)
- Retries LLM call once if response is empty, then falls back to a user-friendly error message
- Adds detailed warning/error logging for null responses (model, finish_reason, usage)
- Makes `max_completion_tokens`, retrieval `top_k`, and search weights configurable via environment variables
- Increases default max_tokens from 4096 to 16384 to prevent reasoning models from exhausting the token budget
- Reduces default top_k for searching_for_information from 12 to 10

## Problems

**Book name mismatch:** When users cite a book via `@` mention, the query enhancement LLM sometimes reformats or slightly alters the book name. Qdrant requires exact string matches for filtering, so any deviation causes zero results — the user gets a response that doesn't reference their cited book.

**Blank chat bubbles:** Users intermittently see empty AI response bubbles. The root cause was the hardcoded `max_completion_tokens=4096` limit. Reasoning models like `gpt-5-nano` allocate tokens between internal reasoning and visible output — with a large prompt (~18K tokens from `top_k=12` retrieval chunks), the model spent all 4096 tokens on reasoning (`reasoning_tokens=4096`, `finish_reason=length`), leaving exactly 0 tokens for the actual response. The OpenAI API returns `content: null` in this case, which propagated unhandled through the backend and was stored as an empty string in PostgreSQL, rendering as a blank bubble in the frontend.

**Hardcoded parameters:** `max_completion_tokens`, `top_k`, and search weights were all hardcoded, requiring code changes to tune.

## Test plan
- Send a chat message citing a book with `@` mention, verify response uses that book's content
- Check logs for book name resolution messages
- Test with a slightly wrong book name (different case) and confirm it still matches
- Verify no more blank bubbles — either a real response or a fallback message
- Check logs for "Empty LLM response" warnings when null occurs
- Set custom `LLM_MAX_TOKENS` in .env, restart, verify it's used
- Verify default values work without setting any new env vars