### PR TITLE
Local LLMs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,42 +59,67 @@ INTENT_SERVICE_URL=http://intent-service:8001
 # ===========================================
 # LLM API Keys & Configuration
 # ===========================================
-# At least ONE of these API keys is required for the RAG system to work.
-# You only need to provide the API key for the provider you plan to use.
+# Provide the API key(s) for the provider(s) you plan to use (or a self-hosted
+# endpoint below). At least one usable model is required for the RAG system to work.
 #
-# For example:
-# - If only using OpenAI models → only set OPENAI_API_KEY
-# - If only using Anthropic models → only set ANTHROPIC_API_KEY
-# - If only using DeepSeek models → only set DEEPSEEK_API_KEY
+# Models are routed to a provider by an explicit "provider/" prefix on the model
+# name (an unprefixed name defaults to OpenAI):
+#   openai/<model>     → OpenAI            e.g. openai/gpt-5-mini
+#   anthropic/<model>  → Anthropic Claude  e.g. anthropic/claude-sonnet-4-6
+#   deepseek/<model>   → DeepSeek          e.g. deepseek/deepseek-chat
+#   local/<model>      → self-hosted endpoint (see LOCAL_LLM_* below)
 
 # OpenAI API key (get from: https://platform.openai.com/api-keys)
-# Example models gpt-5-nano gpt-5-mini etc. (check OpenAI docs for latest models)
 OPENAI_API_KEY=
 
 # Anthropic API key (get from: https://console.anthropic.com/)
-# Example models: claude-4-5 haiku-4-5 opus-4-6 etc. (check Anthropic docs for latest models)
 ANTHROPIC_API_KEY=
 
 # DeepSeek API key (get from: https://platform.deepseek.com/)
-# Example model: deepseek-chat (check DeepSeek docs for latest models)
 DEEPSEEK_API_KEY=
+
+# Optional: override a provider's base URL (e.g. a proxy or compatible gateway).
+# DEEPSEEK_BASE_URL=https://api.deepseek.com/v1
+# ANTHROPIC_BASE_URL=https://api.anthropic.com/v1/    # (pdf-service only)
+
+# --- Local / self-hosted LLM via any OpenAI-compatible endpoint ---
+# Used by models named "local/<served-model-name>". This covers local engines
+# (vLLM, Ollama, LM Studio, llama.cpp, LocalAI) AND hosted OpenAI-compatible
+# providers (OpenRouter, Together, Groq, Fireworks, ...). Only ONE custom
+# endpoint can be configured at a time.
+#
+# The URL is where the api-gateway/pdf containers send requests. Pick by where
+# your server runs:
+#   - Same host, OUTSIDE Docker -> http://host.docker.internal:8000/v1  (default;
+#     the containers map host.docker.internal to the host)
+#   - Another machine / LAN / cloud -> http://192.168.1.50:8000/v1  (its IP/host)
+#   - A service in this compose network -> http://<service>:8000/v1
+# Default ports: vLLM 8000, Ollama 11434, LM Studio 1234.
+LOCAL_LLM_BASE_URL=http://host.docker.internal:8000/v1
+# Token sent to the server; local servers usually ignore it, but the client
+# requires a non-empty value (vLLM convention is "EMPTY"). For a hosted provider,
+# put its API key here.
+LOCAL_LLM_API_KEY=EMPTY
 
 # Models offered in the frontend dropdown. Served at runtime via
 # GET /api/v1/models, so editing this only needs a `docker compose restart
 # api-gateway` (no rebuild). JSON array of {provider, value, label} objects;
-# list only the models you have an API key for.
-AVAILABLE_MODELS=[{"provider":"OpenAI","value":"gpt-5-nano","label":"GPT-5 Nano"},{"provider":"OpenAI","value":"gpt-5-mini","label":"GPT-5 Mini"},{"provider":"Anthropic Claude","value":"claude-haiku-4-5","label":"Claude 4.5 Haiku"},{"provider":"Anthropic Claude","value":"claude-sonnet-4-6","label":"Claude 4.6 Sonnet"}]
+# `value` must carry the "provider/" prefix above. List only models you can reach.
+# Add a self-hosted model with e.g.:
+#   {"provider":"Local","value":"local/Qwen2.5-7B-Instruct","label":"Qwen 2.5 7B (local)"}
+AVAILABLE_MODELS=[{"provider":"OpenAI","value":"openai/gpt-5-nano","label":"GPT-5 Nano"},{"provider":"OpenAI","value":"openai/gpt-5-mini","label":"GPT-5 Mini"},{"provider":"Anthropic Claude","value":"anthropic/claude-haiku-4-5","label":"Claude 4.5 Haiku"},{"provider":"Anthropic Claude","value":"anthropic/claude-sonnet-4-6","label":"Claude 4.6 Sonnet"}]
 
 # Initially-selected model. Must match a `value` in AVAILABLE_MODELS.
-DEFAULT_MODEL_FRONTEND=gpt-5-mini
+DEFAULT_MODEL_FRONTEND=openai/gpt-5-mini
 
-# Model for query enhancement (runs on every query, so use a fast/cheap one)
-# QUERY_ENHANCEMENT_MODEL=gpt-5-nano
+# Model for query enhancement (runs on every query, so use a fast/cheap one).
+# Use a "provider/" prefix (unprefixed = OpenAI).
+# QUERY_ENHANCEMENT_MODEL=openai/gpt-5-nano
 
 # Reasoning effort per pipeline stage ("none", "low", "medium", "high")
 # Controls how much reasoning/thinking the model does at each step.
 # "none" disables reasoning (fastest, cheapest). "high" enables full reasoning.
-# OpenAI: maps to reasoning_effort parameter
+# OpenAI / local: maps to reasoning_effort parameter
 # Anthropic: maps to extended thinking budget
 # DeepSeek: applies to reasoner models only
 # QUERY_ENHANCEMENT_REASONING=none
@@ -133,7 +158,7 @@ DEFAULT_MODEL_FRONTEND=gpt-5-mini
 # AGENT_MAX_ITERATIONS=3
 
 # Model for curation evaluation (should be fast and cheap)
-# AGENT_CURATION_MODEL=gpt-5-nano
+# AGENT_CURATION_MODEL=openai/gpt-5-nano
 
 # Per-iteration timeout (seconds) for the curation model call. On timeout the
 # request fails (SSE `error` event / HTTP 504 for `/single`) rather than generating an answer.
@@ -309,8 +334,9 @@ NEXT_PUBLIC_DEFAULT_SUBJECT=Machine Learning
 # --- PDF Processing Service Advanced ---
 # Model used for chapter/heading detection during PDF processing
 # Used by both DefaultPDFProcessor (TOC classification) and DoclingPDFProcessor (heading hierarchy)
-# Should be a fast, cheap model since it only classifies short heading lists
-# PDF_CHAPTER_DETECTION_MODEL=gpt-5-nano
+# Should be a fast, cheap model since it only classifies short heading lists.
+# Accepts the same "provider/" prefixes as AVAILABLE_MODELS (incl. local/...).
+# PDF_CHAPTER_DETECTION_MODEL=openai/gpt-5-nano
 
 # Maximum PDF upload file size in megabytes
 # Default: 100 (100MB)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,6 +140,11 @@ services:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
       - DEEPSEEK_API_KEY=${DEEPSEEK_API_KEY}
+      # Local / self-hosted OpenAI-compatible endpoint (used by "local/" models).
+      # host.docker.internal reaches an LLM server on the same host (see extra_hosts);
+      # use a LAN IP/hostname for a remote server, or a compose service name.
+      - LOCAL_LLM_BASE_URL=${LOCAL_LLM_BASE_URL:-http://host.docker.internal:8000/v1}
+      - LOCAL_LLM_API_KEY=${LOCAL_LLM_API_KEY:-EMPTY}
       - ENABLE_SNAPSHOT_MANAGEMENT=${ENABLE_SNAPSHOT_MANAGEMENT:-true}
       - ENABLE_PDF_UPLOAD=${ENABLE_PDF_UPLOAD:-true}
       - DOCS_ENABLED=${DOCS_ENABLED:-true}
@@ -177,6 +182,9 @@ services:
       timeout: 10s
       retries: 3
       start_period: 30s
+    # Reach an LLM server running on the host (outside Docker) via host.docker.internal.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     networks:
       - academick-network
     restart: unless-stopped
@@ -205,10 +213,18 @@ services:
       - QDRANT_COLLECTION=${QDRANT_COLLECTION:-academick_embeddings}
       - EMBEDDING_SERVICE_URL=http://embedding-service:8002
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - DEEPSEEK_API_KEY=${DEEPSEEK_API_KEY}
+      # Endpoint for PDF chapter detection (routed by "provider/" prefix).
+      - LOCAL_LLM_BASE_URL=${LOCAL_LLM_BASE_URL:-http://host.docker.internal:8000/v1}
+      - LOCAL_LLM_API_KEY=${LOCAL_LLM_API_KEY:-EMPTY}
+      - PDF_CHAPTER_DETECTION_MODEL=${PDF_CHAPTER_DETECTION_MODEL:-openai/gpt-5-nano}
       - OMP_NUM_THREADS=${OMP_NUM_THREADS:-4}
     volumes:
       - ./Livros:/app/uploads:ro
       - pdf_uploads:/app/processed
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8003/health"]
       interval: 30s
@@ -241,10 +257,18 @@ services:
       - QDRANT_COLLECTION=${QDRANT_COLLECTION:-academick_embeddings}
       - EMBEDDING_SERVICE_URL=http://embedding-service:8002
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - DEEPSEEK_API_KEY=${DEEPSEEK_API_KEY}
+      # Endpoint for PDF chapter detection (routed by "provider/" prefix).
+      - LOCAL_LLM_BASE_URL=${LOCAL_LLM_BASE_URL:-http://host.docker.internal:8000/v1}
+      - LOCAL_LLM_API_KEY=${LOCAL_LLM_API_KEY:-EMPTY}
+      - PDF_CHAPTER_DETECTION_MODEL=${PDF_CHAPTER_DETECTION_MODEL:-openai/gpt-5-nano}
       - OMP_NUM_THREADS=${OMP_NUM_THREADS:-4}
     volumes:
       - ./Livros:/app/uploads:ro
       - pdf_uploads:/app/processed
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     healthcheck:
       test: ["CMD-SHELL", "celery -A app.workers.celery_app inspect ping -d celery@$$HOSTNAME || exit 1"]
       interval: 30s

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -232,9 +232,12 @@ curl -X DELETE "http://localhost/api/v1/admin/snapshots/{snapshot_name}?session_
 | `SESSION_SECRET` | Session token encryption key |
 | `ADMIN_PASSWORD` | Admin user password |
 | `GUEST_PASSWORD` | Guest user password |
-| `OPENAI_API_KEY` | OpenAI API key (at least one LLM key required) |
-| `ANTHROPIC_API_KEY` | Anthropic API key (at least one LLM key required) |
-| `DEEPSEEK_API_KEY` | DeepSeek API key (at least one LLM key required) |
+| `OPENAI_API_KEY` | OpenAI API key (at least one LLM provider required) |
+| `ANTHROPIC_API_KEY` | Anthropic API key (at least one LLM provider required) |
+| `DEEPSEEK_API_KEY` | DeepSeek API key (at least one LLM provider required) |
+
+> A self-hosted OpenAI-compatible server (vLLM, Ollama, …) counts as an LLM
+> provider and needs no API key — see [Local LLMs](local-llms.md).
 
 ### General
 
@@ -249,11 +252,20 @@ curl -X DELETE "http://localhost/api/v1/admin/snapshots/{snapshot_name}?session_
 
 ### LLM & RAG
 
+Models are routed to a provider by an explicit `provider/` prefix on the model
+name — `openai/`, `anthropic/`, `deepseek/`, or `local/` (an unprefixed name
+defaults to OpenAI). Every `*_MODEL` value and every `AVAILABLE_MODELS` entry
+should carry this prefix. See [Local LLMs](local-llms.md) for self-hosting and the
+full routing rules.
+
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `AVAILABLE_MODELS` | _(required)_ | JSON array of `{provider, value, label}` models offered in the frontend dropdown; served at runtime via `GET /api/v1/models` |
+| `AVAILABLE_MODELS` | _(required)_ | JSON array of `{provider, value, label}` models offered in the frontend dropdown; each `value` must start with a `provider/` prefix. Served at runtime via `GET /api/v1/models`; validated at startup |
 | `DEFAULT_MODEL_FRONTEND` | _(required)_ | Initially-selected model; must match a `value` in `AVAILABLE_MODELS` |
-| `QUERY_ENHANCEMENT_MODEL` | `gpt-5-nano` | Model for generating focused search queries (runs on every query) |
+| `QUERY_ENHANCEMENT_MODEL` | `openai/gpt-5-nano` | Model for generating focused search queries (runs on every query). Uses structured output — **must support tool calling** |
+| `LOCAL_LLM_BASE_URL` | `http://host.docker.internal:8000/v1` | OpenAI-compatible base URL for `local/` models (self-hosted server on the same host by default) |
+| `LOCAL_LLM_API_KEY` | `EMPTY` | Token for the local LLM server (most ignore it; the client requires a non-empty value) |
+| `DEEPSEEK_BASE_URL` | `https://api.deepseek.com/v1` | DeepSeek base URL (override for a proxy/gateway) |
 | `LLM_MAX_TOKENS` | `16384` | Maximum completion tokens (increase for reasoning models) |
 | `TOP_K_SEARCHING` | `10` | Retrieval chunks for `searching_for_information` intent |
 | `TOP_K_DEFAULT` | `6` | Retrieval chunks for all other intents |
@@ -271,7 +283,7 @@ curl -X DELETE "http://localhost/api/v1/admin/snapshots/{snapshot_name}?session_
 |----------|---------|-------------|
 | `AGENT_ENABLED` | `true` | Enable the curation agent (disable for single-pass RAG) |
 | `AGENT_MAX_ITERATIONS` | `3` | Maximum curation iterations before forcing approval |
-| `AGENT_CURATION_MODEL` | `gpt-5-nano` | Model for curation evaluation (should be fast and cheap) |
+| `AGENT_CURATION_MODEL` | `openai/gpt-5-nano` | Model for curation evaluation (fast and cheap). Uses structured output — **must support tool calling** |
 | `AGENT_CURATION_REASONING` | `none` | Reasoning effort for the curation agent (`none`, `low`, `medium`, `high`) |
 | `AGENT_CURATION_TIMEOUT` | `60` | Per-iteration timeout (seconds) for the curation model call; on timeout the request fails (SSE `error` event / HTTP 504 on `/single`) |
 | `AGENT_CURATION_MAX_TOKENS` | `4096` | Max response tokens for the curation model (also scales the Anthropic thinking budget) |
@@ -310,7 +322,7 @@ curl -X DELETE "http://localhost/api/v1/admin/snapshots/{snapshot_name}?session_
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `PDF_CHAPTER_DETECTION_MODEL` | `gpt-5-nano` | LLM model for chapter/heading classification during PDF processing |
+| `PDF_CHAPTER_DETECTION_MODEL` | `openai/gpt-5-nano` | LLM for chapter/heading classification during PDF processing. Accepts any `provider/` prefix (incl. `local/`); plain text, no tool calling required |
 | `MAX_UPLOAD_SIZE_MB` | `100` | Maximum PDF upload size in megabytes |
 | `CHUNK_SIZE` | `3000` | Text chunk size in characters (**changing requires re-processing all PDFs**) |
 | `CHUNK_OVERLAP` | `1000` | Character overlap between chunks (must be less than `CHUNK_SIZE`) |

--- a/docs/local-llms.md
+++ b/docs/local-llms.md
@@ -1,0 +1,217 @@
+# Using Local / Self-Hosted LLMs
+
+AcademiCK can run entirely against a **self-hosted LLM** instead of (or alongside)
+OpenAI, Anthropic, and DeepSeek. Any server that exposes an **OpenAI-compatible
+`/v1` API** works — including [vLLM](https://docs.vllm.ai/),
+[Ollama](https://ollama.com/), [LM Studio](https://lmstudio.ai/),
+[llama.cpp](https://github.com/ggml-org/llama.cpp) (`llama-server`), and
+[LocalAI](https://localai.io/).
+
+No extra dependencies are required: the services already use the `openai` SDK to
+talk to any compatible endpoint.
+
+## How model routing works
+
+Every model name carries an explicit **`provider/` prefix** that decides where the
+request goes. An unprefixed name defaults to OpenAI.
+
+| Prefix       | Routed to                                 | Example                       |
+| ------------ | ----------------------------------------- | ----------------------------- |
+| `openai/`    | OpenAI                                     | `openai/gpt-5-mini`           |
+| `anthropic/` | Anthropic Claude                           | `anthropic/claude-sonnet-4-6` |
+| `deepseek/`  | DeepSeek                                    | `deepseek/deepseek-chat`      |
+| `local/`     | Your self-hosted endpoint (`LOCAL_LLM_*`)  | `local/Qwen2.5-7B-Instruct`   |
+
+For a `local/` model, everything after the prefix is the **served model name** —
+exactly what your server expects (it may itself contain slashes, e.g.
+`local/meta-llama/Llama-3.1-8B-Instruct` → served as
+`meta-llama/Llama-3.1-8B-Instruct`).
+
+This prefix is used everywhere a model is selected: the frontend dropdown
+(`AVAILABLE_MODELS`), query enhancement, the curation agent, and PDF chapter
+detection.
+
+## Configuration
+
+Two environment variables point AcademiCK at your server:
+
+| Variable             | Default                              | Description                                                                 |
+| -------------------- | ------------------------------------ | --------------------------------------------------------------------------- |
+| `LOCAL_LLM_BASE_URL` | `http://host.docker.internal:8000/v1` | OpenAI-compatible base URL. The default reaches a server on the **same host** as Docker (port 8000). |
+| `LOCAL_LLM_API_KEY`  | `EMPTY`                              | Token sent to the server. Most local servers ignore it, but the client requires a non-empty value. Set it if your server enforces a key. |
+
+The Compose file already injects these (with the defaults above) and wires
+`host.docker.internal` into the relevant services via `extra_hosts`, so a server
+running on the same host as Docker on port 8000 works out of the box — you only
+need to add the model to `AVAILABLE_MODELS`.
+
+## Quick start (vLLM on the same host)
+
+### 1. Start a vLLM server
+
+```bash
+# On a machine with a GPU
+pip install vllm
+vllm serve Qwen/Qwen2.5-7B-Instruct --port 8000
+```
+
+This exposes an OpenAI-compatible API at `http://localhost:8000/v1` on the host,
+which Docker reaches as `http://host.docker.internal:8000/v1` (the default).
+
+### 2. Add the model to the frontend dropdown
+
+`AVAILABLE_MODELS` is a JSON array of `{provider, value, label}`. The `value` must
+carry the `local/` prefix; `provider` and `label` are just display text.
+
+```env
+AVAILABLE_MODELS=[{"provider":"Local","value":"local/Qwen/Qwen2.5-7B-Instruct","label":"Qwen 2.5 7B (local)"}]
+DEFAULT_MODEL_FRONTEND=local/Qwen/Qwen2.5-7B-Instruct
+```
+
+You can mix cloud and local entries in the same list:
+
+```env
+AVAILABLE_MODELS=[{"provider":"OpenAI","value":"openai/gpt-5-mini","label":"GPT-5 Mini"},{"provider":"Local","value":"local/Qwen/Qwen2.5-7B-Instruct","label":"Qwen 2.5 7B (local)"}]
+```
+
+If your server runs on a different port, host, or as a Compose service, override
+the base URL — see [Pointing at a different server](#pointing-at-a-different-server).
+
+### 3. Recreate the containers
+
+`AVAILABLE_MODELS` and the `LOCAL_LLM_*` vars are injected from `.env` at container
+**creation** time. `docker compose restart` reuses the old environment — you must
+recreate:
+
+```bash
+docker compose up -d api-gateway pdf-service pdf-worker
+```
+
+Hard-refresh the browser so it re-fetches the model list from `GET /api/v1/models`.
+
+## Other servers
+
+The only thing that changes is the served model name (and the port, if not 8000).
+
+| Server     | Default port | Served name (`local/<name>`)                          |
+| ---------- | ------------ | ----------------------------------------------------- |
+| vLLM       | 8000         | The HF repo you launched, e.g. `Qwen/Qwen2.5-7B-Instruct` |
+| Ollama     | 11434        | The Ollama model tag, e.g. `llama3.1`                 |
+| LM Studio  | 1234         | The model identifier shown in LM Studio               |
+| llama.cpp  | 8080         | Arbitrary (`llama-server` exposes `/v1`)              |
+| LocalAI    | 8080         | The configured model name                             |
+
+## Pointing at a different server
+
+Override `LOCAL_LLM_BASE_URL` in `.env`:
+
+- **Different port on the same host** (e.g. Ollama):
+  `LOCAL_LLM_BASE_URL=http://host.docker.internal:11434/v1`
+- **A remote server on your network**:
+  `LOCAL_LLM_BASE_URL=http://192.168.1.50:8000/v1`
+- **Another Compose service** — use the service name, e.g.
+  `LOCAL_LLM_BASE_URL=http://vllm:8000/v1`. Example service for `docker-compose.yml`:
+
+  ```yaml
+  vllm:
+    image: vllm/vllm-openai:latest
+    command: ["--model", "Qwen/Qwen2.5-7B-Instruct"]
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+  ```
+
+## Per-stage models
+
+You don't have to use the same model everywhere. Each of these accepts a prefixed
+model name independently, so you can keep a cheap cloud model for light stages and
+a local model for the main answer, or vice versa:
+
+| Variable                      | Stage                                   | Needs tool calling |
+| ----------------------------- | --------------------------------------- | ------------------ |
+| `AVAILABLE_MODELS` (selected) | Main answer generation                  | No (plain text)    |
+| `QUERY_ENHANCEMENT_MODEL`     | Search-query generation (every query)   | **Yes**            |
+| `AGENT_CURATION_MODEL`        | Context curation agent                  | **Yes**            |
+| `PDF_CHAPTER_DETECTION_MODEL` | Chapter/heading detection during upload | No (plain text)    |
+
+Example — run everything locally:
+
+```env
+QUERY_ENHANCEMENT_MODEL=local/Qwen/Qwen2.5-7B-Instruct
+AGENT_CURATION_MODEL=local/Qwen/Qwen2.5-7B-Instruct
+PDF_CHAPTER_DETECTION_MODEL=local/Qwen/Qwen2.5-7B-Instruct
+```
+
+> PDF chapter detection talks to providers through their OpenAI-compatible
+> endpoints, so `anthropic/…` and `deepseek/…` work there too (not just `openai/`
+> and `local/`).
+
+### Tool calling is required for the agent stages
+
+The query-enhancement and curation stages run through Pydantic AI with **typed
+structured outputs**, which are implemented as **tool/function calls**. A local
+model used for `QUERY_ENHANCEMENT_MODEL` or `AGENT_CURATION_MODEL` **must support
+tool calling**, and your server must expose it through the OpenAI-compatible API
+(e.g. vLLM started with `--enable-auto-tool-choice` and a matching
+`--tool-call-parser`). If the model can't call tools, these stages fail.
+
+Pick a tool-calling-capable model (e.g. Qwen2.5-Instruct, Llama 3.1 Instruct,
+Mistral/Mixtral Instruct, Hermes) for those stages. The **main answer model** and
+**PDF chapter detection** generate plain text and do **not** require tool calling —
+if your local model lacks it, you can still use it there while pointing the agent
+stages at a capable model (local or cloud).
+
+## Reasoning effort
+
+The `*_REASONING` settings (`none`, `low`, `medium`, `high`) are passed to local
+models as the OpenAI `reasoning_effort` parameter when not `none`. Most
+self-hosted models **do not** support this and will reject the request. Unless your
+served model explicitly supports reasoning effort, leave the reasoning settings at
+`none` for local models.
+
+## Provider base URL overrides
+
+If you route a cloud provider through a proxy or compatible gateway, you can
+override its base URL (defaults shown):
+
+```env
+DEEPSEEK_BASE_URL=https://api.deepseek.com/v1
+ANTHROPIC_BASE_URL=https://api.anthropic.com/v1/   # pdf-service only
+```
+
+## Troubleshooting
+
+**`model '<name>' does not exist` / 404 from `api.openai.com`**
+The model name reached the backend **without** a `provider/` prefix and fell
+through to the OpenAI default. Make sure every `AVAILABLE_MODELS` value and every
+`*_MODEL` setting carries a prefix, and that you ran `docker compose up -d` (not
+`restart`) so the container picked up the updated values.
+
+**Gateway refuses to start: "AVAILABLE_MODELS value … must start with a provider prefix"**
+This is the startup guard working as intended — fix the offending entry to include
+a prefix (e.g. `anthropic/claude-haiku-4-5`, not `claude-haiku-4-5`).
+
+**"A 'local/' model was selected but LOCAL_LLM_BASE_URL is not set."**
+You explicitly set `LOCAL_LLM_BASE_URL` to an empty value. Remove the override (to
+fall back to the default) or set a real URL, then recreate the containers.
+
+**Connection refused / timeout reaching the local server**
+The URL is resolved from inside a container, so `localhost` means the container,
+not your host. Use `host.docker.internal` (the default), the host's LAN IP, or the
+Compose service name. Confirm the server is reachable from a container:
+`docker compose exec api-gateway curl -s $LOCAL_LLM_BASE_URL/models`.
+
+**Empty or truncated answers**
+Raise `LLM_MAX_TOKENS`, and make sure your server was launched with a large enough
+context/max-model-len for the prompt plus the answer.
+
+**Query enhancement or curation fails (tool/function-call errors)**
+The model set for `QUERY_ENHANCEMENT_MODEL` / `AGENT_CURATION_MODEL` doesn't
+support tool calling, or your server doesn't expose it. Use a tool-calling-capable
+model and enable tool support on the server (for vLLM,
+`--enable-auto-tool-choice --tool-call-parser <parser>`). See
+[Tool calling is required for the agent stages](#tool-calling-is-required-for-the-agent-stages).

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ The system is **subject-agnostic** — configure it for Machine Learning, Organi
 
 - **Hybrid Vector Search** — Combines dense and sparse embeddings (BGE-M3) with intent-tuned weighted score fusion for accurate retrieval
 - **Intent-Aware Queries** — Custom classifier detects query type (Q&A, summarization, coding, search) and adapts behavior
-- **Multi-Provider LLM** — Choose between OpenAI, Anthropic, or DeepSeek models per query
+- **Multi-Provider LLM** — Choose between OpenAI, Anthropic, DeepSeek, or self-hosted local models (vLLM, Ollama, …) per query
 - **Agentic Context Curation** — Multi-iteration agent drops noise and fetches missing context before answer generation
 - **PDF Processing Pipeline** — Two-tier processing cascade: LLM-based and layout-based (Docling) with per-chunk page tracking
 - **Session Management** — Redis-backed sessions with conversation history and context
@@ -58,7 +58,7 @@ The system is **subject-agnostic** — configure it for Machine Learning, Organi
 | Classifier| |  Service   | | Vectors  | |  Cache   | |  Database  |
 +-----------+ +------------+ +----------+ +----------+ +------------+
 
-                    LLM APIs: OpenAI / Anthropic / DeepSeek
+           LLM APIs: OpenAI / Anthropic / DeepSeek / Local (vLLM, Ollama, …)
 ```
 
 > All internal services communicate over an isolated Docker network. Only nginx is exposed to the host.
@@ -94,7 +94,7 @@ All three LLM stages (query enhancement, curation, answer) run through Pydantic 
 ### Prerequisites
 
 - **Docker** and **Docker Compose** v2.0+
-- At least one LLM API key ([OpenAI](https://platform.openai.com/api-keys), [Anthropic](https://console.anthropic.com/), or [DeepSeek](https://platform.deepseek.com/))
+- At least one LLM provider: an API key ([OpenAI](https://platform.openai.com/api-keys), [Anthropic](https://console.anthropic.com/), or [DeepSeek](https://platform.deepseek.com/)), or a self-hosted OpenAI-compatible server (see [Local LLMs](docs/local-llms.md))
 - **16GB+ RAM** recommended for smooth performance
 - **NVIDIA GPU** with CUDA (recommended) — or set `EMBEDDING_DEVICE=cpu` for CPU-only mode
 
@@ -166,8 +166,10 @@ Key settings in `.env` (see [.env.example](.env.example) and [docs/USAGE.md](doc
 | `OPENAI_API_KEY`            | At least one | OpenAI API key                                         |
 | `ANTHROPIC_API_KEY`         | At least one | Anthropic API key                                      |
 | `DEEPSEEK_API_KEY`          | At least one | DeepSeek API key                                       |
+| `LOCAL_LLM_BASE_URL`        | No           | OpenAI-compatible URL for a self-hosted LLM (default: `http://host.docker.internal:8000/v1`). See [Local LLMs](docs/local-llms.md) |
+| `LOCAL_LLM_API_KEY`         | No           | Token for the local LLM server (default: `EMPTY`)      |
 | `DEFAULT_SUBJECT`           | No           | Academic subject (default: Machine Learning)           |
-| `AVAILABLE_MODELS`          | Yes          | JSON array of models offered in the frontend dropdown  |
+| `AVAILABLE_MODELS`          | Yes          | JSON array of models for the frontend dropdown; each `value` needs a `provider/` prefix (`openai/`, `anthropic/`, `deepseek/`, `local/`) |
 | `DEFAULT_MODEL_FRONTEND`    | Yes          | Initially-selected model (a `value` in `AVAILABLE_MODELS`) |
 | `AGENT_ENABLED`             | No           | Enable curation agent (default: true)                  |
 | `REASONING_TRACE_VISIBLE`   | No           | Expose the agent's reasoning trace in the chat UI (default: false) |
@@ -197,6 +199,7 @@ Key settings in `.env` (see [.env.example](.env.example) and [docs/USAGE.md](doc
 | Document                     | Description                                                    |
 | ---------------------------- | -------------------------------------------------------------- |
 | [Usage Guide](docs/USAGE.md)    | API examples, admin dashboard, PDF processing, troubleshooting |
+| [Local LLMs](docs/local-llms.md) | Run against a self-hosted LLM (vLLM, Ollama, …) and provider routing |
 | [Database Schema](docs/database.md) | PostgreSQL tables, relationships, and analytics            |
 | [Vector Store](docs/qdrant.md)  | Qdrant collection, vectors, payload, and retrieval             |
 | [Known Issues](docs/KNOWN_ISSUES.md) | Logged problems, root causes, and workarounds            |

--- a/services/api-gateway/app/config.py
+++ b/services/api-gateway/app/config.py
@@ -17,6 +17,13 @@ from pydantic_settings import BaseSettings
 from typing import List, Optional
 
 
+# Models are routed to a provider by an explicit "provider/" name prefix
+# (see app/services/agent_models.py). Canonical list, also used to validate
+# AVAILABLE_MODELS at startup so a misprefixed model fails fast instead of
+# silently falling through to OpenAI at request time.
+KNOWN_PROVIDER_PREFIXES = ("openai/", "anthropic/", "deepseek/", "local/")
+
+
 def _require_env(name: str) -> str:
     """Get a required environment variable or raise an error."""
     value = os.getenv(name)
@@ -64,12 +71,20 @@ class Settings(BaseSettings):
     anthropic_api_key: Optional[str] = os.getenv("ANTHROPIC_API_KEY")
     deepseek_api_key: Optional[str] = os.getenv("DEEPSEEK_API_KEY")
 
+    # Provider base URLs (override to use a proxy or an OpenAI-compatible gateway).
+    deepseek_base_url: str = os.getenv("DEEPSEEK_BASE_URL", "https://api.deepseek.com/v1")
+
+    # Local / self-hosted OpenAI-compatible endpoint (vLLM, Ollama, LM Studio, ...).
+    # Used by models whose name is prefixed with "local/".
+    local_llm_base_url: Optional[str] = os.getenv("LOCAL_LLM_BASE_URL")
+    local_llm_api_key: str = os.getenv("LOCAL_LLM_API_KEY", "EMPTY")
+
     # Frontend model selector, served at runtime via GET /api/v1/models.
     available_models_raw: str = _require_env("AVAILABLE_MODELS")
     default_model_frontend: str = _require_env("DEFAULT_MODEL_FRONTEND")
 
     # Model for query enhancement (fast and cheap, runs on every query)
-    query_enhancement_model: str = os.getenv("QUERY_ENHANCEMENT_MODEL", "gpt-5-nano")
+    query_enhancement_model: str = os.getenv("QUERY_ENHANCEMENT_MODEL", "openai/gpt-5-nano")
 
     # Reasoning effort per pipeline stage ("none", "low", "medium", "high")
     query_enhancement_reasoning: str = os.getenv("QUERY_ENHANCEMENT_REASONING", "none")
@@ -95,7 +110,7 @@ class Settings(BaseSettings):
     # Agentic RAG (context curation)
     agent_enabled: bool = os.getenv("AGENT_ENABLED", "true").lower() == "true"
     agent_max_iterations: int = int(os.getenv("AGENT_MAX_ITERATIONS", "3"))
-    agent_curation_model: str = os.getenv("AGENT_CURATION_MODEL", "gpt-5-nano")
+    agent_curation_model: str = os.getenv("AGENT_CURATION_MODEL", "openai/gpt-5-nano")
     agent_curation_reasoning: str = os.getenv("AGENT_CURATION_REASONING", "none")
     agent_curation_timeout: float = float(os.getenv("AGENT_CURATION_TIMEOUT", "60"))
     agent_curation_max_tokens: int = int(os.getenv("AGENT_CURATION_MAX_TOKENS", "4096"))
@@ -149,6 +164,12 @@ def _parse_frontend_models(raw: str, default: str) -> List[dict]:
             raise RuntimeError(
                 "Each AVAILABLE_MODELS entry must be an object with non-empty string "
                 "'provider', 'value' and 'label' keys."
+            )
+        if not item["value"].startswith(KNOWN_PROVIDER_PREFIXES):
+            raise RuntimeError(
+                f'AVAILABLE_MODELS value "{item["value"]}" must start with a provider '
+                f'prefix {KNOWN_PROVIDER_PREFIXES} (e.g. "anthropic/claude-haiku-4-5"). '
+                f"Without a prefix the model would be sent to OpenAI."
             )
 
     if not any(item["value"] == default for item in parsed):

--- a/services/api-gateway/app/services/agent_models.py
+++ b/services/api-gateway/app/services/agent_models.py
@@ -15,16 +15,27 @@ from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.openai import OpenAIProvider
 from pydantic_ai.settings import ModelSettings
 
-from app.config import settings
+from app.config import settings, KNOWN_PROVIDER_PREFIXES
 
 
-def _provider_for(model_name: str) -> str:
-    name = model_name.lower()
-    if name.startswith("claude"):
-        return "anthropic"
-    if name.startswith("deepseek"):
-        return "deepseek"
-    return "openai"
+# Provider routing by explicit "provider/" name prefix. Using prefixes (rather
+# than guessing from the bare model name) keeps routing robust to new model
+# names and makes adding a provider a one-line change. An unprefixed name
+# defaults to OpenAI. Derived from the canonical KNOWN_PROVIDER_PREFIXES so the
+# router and the AVAILABLE_MODELS validator can't drift apart.
+_PROVIDER_PREFIXES = {prefix: prefix.rstrip("/") for prefix in KNOWN_PROVIDER_PREFIXES}
+
+
+def _resolve_model(model_name: str) -> tuple[str, str]:
+    """Map a model name to (provider, served_model_name).
+
+    The served name is the model name with its "provider/" prefix removed, i.e.
+    what the provider's API actually expects.
+    """
+    for prefix, provider in _PROVIDER_PREFIXES.items():
+        if model_name.startswith(prefix):
+            return provider, model_name[len(prefix):]
+    return "openai", model_name
 
 
 def _anthropic_thinking_budget(reasoning_effort: str, max_tokens: int) -> Optional[int]:
@@ -47,14 +58,37 @@ def build_model(
     max_tokens caps the response (defaults to settings.llm_max_tokens) and,
     for Anthropic, scales the thinking budget.
 
+    Routing is by explicit "provider/" name prefix (see _resolve_model); an
+    unprefixed name defaults to OpenAI.
+
     reasoning_effort is one of "none", "low", "medium", "high". The mapping
     to provider-specific knobs is:
       - OpenAI: passed as openai_reasoning_effort (ignored when "none").
       - Anthropic: mapped to thinking budget_tokens (disabled when "none").
       - DeepSeek: passed as openai_reasoning_effort for reasoner models only.
+      - local: OpenAI-compatible self-hosted endpoint; reasoning passed as
+        openai_reasoning_effort when not "none".
     """
-    provider = _provider_for(model_name)
+    provider, served_name = _resolve_model(model_name)
     max_tokens = max_tokens or settings.llm_max_tokens
+
+    if provider == "local":
+        if not settings.local_llm_base_url:
+            raise RuntimeError(
+                "A 'local/' model was selected but LOCAL_LLM_BASE_URL is not set."
+            )
+        provider_obj = OpenAIProvider(
+            base_url=settings.local_llm_base_url,
+            api_key=settings.local_llm_api_key,
+        )
+        model_settings = {"max_tokens": max_tokens}
+        if reasoning_effort != "none":
+            model_settings["openai_reasoning_effort"] = reasoning_effort
+        return OpenAIChatModel(
+            served_name,
+            provider=provider_obj,
+            settings=ModelSettings(**model_settings),
+        )
 
     if provider == "anthropic":
         budget = _anthropic_thinking_budget(reasoning_effort, max_tokens)
@@ -64,18 +98,18 @@ def build_model(
                 "type": "enabled",
                 "budget_tokens": budget,
             }
-        return AnthropicModel(model_name, settings=ModelSettings(**model_settings))
+        return AnthropicModel(served_name, settings=ModelSettings(**model_settings))
 
     if provider == "deepseek":
         provider_obj = OpenAIProvider(
-            base_url="https://api.deepseek.com/v1",
+            base_url=settings.deepseek_base_url,
             api_key=settings.deepseek_api_key,
         )
         model_settings = {"max_tokens": max_tokens}
-        if reasoning_effort != "none" and "reasoner" in model_name.lower():
+        if reasoning_effort != "none" and "reasoner" in served_name.lower():
             model_settings["openai_reasoning_effort"] = reasoning_effort
         return OpenAIChatModel(
-            model_name,
+            served_name,
             provider=provider_obj,
             settings=ModelSettings(**model_settings),
         )
@@ -84,4 +118,4 @@ def build_model(
     model_settings = {"max_completion_tokens": max_tokens}
     if reasoning_effort != "none":
         model_settings["openai_reasoning_effort"] = reasoning_effort
-    return OpenAIChatModel(model_name, settings=ModelSettings(**model_settings))
+    return OpenAIChatModel(served_name, settings=ModelSettings(**model_settings))

--- a/services/embedding-service/app/main.py
+++ b/services/embedding-service/app/main.py
@@ -77,7 +77,7 @@ async def lifespan(app: FastAPI):
 
         model = BGEM3FlagModel(
             settings.model_name,
-            device=device.type,  # "cuda" or "cpu"
+            devices=device.type,  # "cuda" or "cpu"
             use_fp16=settings.use_fp16 and device.type == "cuda"
         )
 

--- a/services/frontend/components/ContentManagement.tsx
+++ b/services/frontend/components/ContentManagement.tsx
@@ -715,7 +715,17 @@ const ContentManagement = () => {
                                             )}
                                         </div>
                                     </div>
-                                    <Progress value={job.progress} className="h-2" />
+                                    <Progress
+                                        value={job.status === 'failed' || job.status === 'cancelled' ? 100 : job.progress}
+                                        className="h-2"
+                                        indicatorClassName={
+                                            job.status === 'failed'
+                                                ? 'bg-red-500'
+                                                : job.status === 'cancelled'
+                                                    ? 'bg-orange-400'
+                                                    : undefined
+                                        }
+                                    />
                                     {job.warning && (
                                         <div className="flex items-center gap-2 p-2 rounded bg-yellow-50 border border-yellow-200">
                                             <AlertTriangle className="h-4 w-4 text-yellow-600 flex-shrink-0" />
@@ -723,7 +733,10 @@ const ContentManagement = () => {
                                         </div>
                                     )}
                                     {job.error && (
-                                        <p className="text-sm text-red-500">{job.error}</p>
+                                        <div className="flex items-start gap-2 p-2 rounded bg-red-50 border border-red-200">
+                                            <AlertCircle className="h-4 w-4 text-red-600 flex-shrink-0 mt-0.5" />
+                                            <span className="text-sm text-red-700 break-words">{job.error}</span>
+                                        </div>
                                     )}
                                 </div>
                             ))}

--- a/services/frontend/components/ui/progress.tsx
+++ b/services/frontend/components/ui/progress.tsx
@@ -7,8 +7,10 @@ import { cn } from "@/lib/utils"
 
 const Progress = React.forwardRef<
   React.ElementRef<typeof ProgressPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
->(({ className, value, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root> & {
+    indicatorClassName?: string
+  }
+>(({ className, value, indicatorClassName, ...props }, ref) => (
   <ProgressPrimitive.Root
     ref={ref}
     className={cn(
@@ -18,7 +20,7 @@ const Progress = React.forwardRef<
     {...props}
   >
     <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-primary transition-all"
+      className={cn("h-full w-full flex-1 bg-primary transition-all", indicatorClassName)}
       style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
     />
   </ProgressPrimitive.Root>

--- a/services/pdf-service/app/config.py
+++ b/services/pdf-service/app/config.py
@@ -42,9 +42,25 @@ class Settings(BaseSettings):
         "EMBEDDING_SERVICE_URL", "http://localhost:8002"
     )
 
-    # OpenAI for TOC analysis
+    # LLM for TOC / chapter analysis. The model is routed to its provider by a
+    # "provider/" name prefix (see app/services/llm_client.py).
     openai_api_key: str = os.getenv("OPENAI_API_KEY", "")
-    pdf_chapter_detection_model: str = os.getenv("PDF_CHAPTER_DETECTION_MODEL", "gpt-5-nano")
+    anthropic_api_key: str = os.getenv("ANTHROPIC_API_KEY", "")
+    deepseek_api_key: str = os.getenv("DEEPSEEK_API_KEY", "")
+    pdf_chapter_detection_model: str = os.getenv("PDF_CHAPTER_DETECTION_MODEL", "openai/gpt-5-nano")
+
+    # Provider base URLs (override to use a proxy or an OpenAI-compatible gateway).
+    anthropic_base_url: str = os.getenv("ANTHROPIC_BASE_URL", "https://api.anthropic.com/v1/")
+    deepseek_base_url: str = os.getenv("DEEPSEEK_BASE_URL", "https://api.deepseek.com/v1")
+
+    # Local / self-hosted OpenAI-compatible endpoint, used by "local/" models.
+    local_llm_base_url: str = os.getenv("LOCAL_LLM_BASE_URL", "")
+    local_llm_api_key: str = os.getenv("LOCAL_LLM_API_KEY", "EMPTY")
+
+    # Local / self-hosted OpenAI-compatible endpoint, used when the model name
+    # is prefixed with "local/".
+    local_llm_base_url: str = os.getenv("LOCAL_LLM_BASE_URL", "")
+    local_llm_api_key: str = os.getenv("LOCAL_LLM_API_KEY", "EMPTY")
 
     # Processing settings
     chunk_size: int = int(os.getenv("CHUNK_SIZE", "3000"))

--- a/services/pdf-service/app/config.py
+++ b/services/pdf-service/app/config.py
@@ -53,10 +53,6 @@ class Settings(BaseSettings):
     anthropic_base_url: str = os.getenv("ANTHROPIC_BASE_URL", "https://api.anthropic.com/v1/")
     deepseek_base_url: str = os.getenv("DEEPSEEK_BASE_URL", "https://api.deepseek.com/v1")
 
-    # Local / self-hosted OpenAI-compatible endpoint, used by "local/" models.
-    local_llm_base_url: str = os.getenv("LOCAL_LLM_BASE_URL", "")
-    local_llm_api_key: str = os.getenv("LOCAL_LLM_API_KEY", "EMPTY")
-
     # Local / self-hosted OpenAI-compatible endpoint, used when the model name
     # is prefixed with "local/".
     local_llm_base_url: str = os.getenv("LOCAL_LLM_BASE_URL", "")

--- a/services/pdf-service/app/services/default_pdf_processor.py
+++ b/services/pdf-service/app/services/default_pdf_processor.py
@@ -13,9 +13,9 @@ from typing import List, Dict, Optional
 import fitz  # PyMuPDF
 from pypdf import PdfReader
 from langchain.text_splitter import NLTKTextSplitter
-from openai import OpenAI
 
 from app.config import settings
+from app.services.llm_client import build_chat_client
 
 logger = logging.getLogger(__name__)
 
@@ -33,8 +33,7 @@ class DefaultPDFProcessor:
 
     def __init__(self, llm_model: str = settings.pdf_chapter_detection_model):
         """Initialize the DefaultPDFProcessor."""
-        self.model = llm_model
-        self.client = OpenAI(api_key=settings.openai_api_key)
+        self.client, self.model = build_chat_client(llm_model)
         self.chunk_size = settings.chunk_size  # Default 3000
         self.chunk_overlap = settings.chunk_overlap  # Default 1000
         self.min_chunk_length = settings.min_chunk_length  # Default 300

--- a/services/pdf-service/app/services/docling_pdf_processor.py
+++ b/services/pdf-service/app/services/docling_pdf_processor.py
@@ -6,6 +6,7 @@ import re
 from typing import List, Dict, Set
 
 from app.config import settings
+from app.services.llm_client import build_chat_client
 
 logger = logging.getLogger(__name__)
 
@@ -141,11 +142,7 @@ class DoclingPDFProcessor:
         the full set of headings so every heading becomes a chapter (flat fallback).
         """
         try:
-            if not settings.openai_api_key:
-                raise ValueError("No OpenAI API key configured")
-
-            from openai import OpenAI
-            client = OpenAI(api_key=settings.openai_api_key)
+            client, model = build_chat_client(self.model)
 
             headings_text = "\n".join(f"- {h}" for h in headings)
             prompt = (
@@ -158,7 +155,7 @@ class DoclingPDFProcessor:
             )
 
             completion = client.chat.completions.create(
-                model=self.model,
+                model=model,
                 messages=[{"role": "user", "content": prompt}],
             )
             answer = completion.choices[0].message.content.strip()

--- a/services/pdf-service/app/services/llm_client.py
+++ b/services/pdf-service/app/services/llm_client.py
@@ -1,0 +1,66 @@
+"""OpenAI-compatible chat client factory.
+
+Single place that maps a chapter-detection model name to an OpenAI client.
+Routing is by explicit "provider/" name prefix (an unprefixed name defaults to
+OpenAI), pointing the client at each provider's OpenAI-compatible endpoint so the
+PDF processors keep using a single chat.completions interface:
+  - "local/…"     → self-hosted endpoint (vLLM, Ollama, ...)
+  - "anthropic/…" → Anthropic OpenAI-compatible endpoint
+  - "deepseek/…"  → DeepSeek
+  - "openai/…"    → OpenAI
+The "provider/" prefix is stripped from the returned model name. Provider base
+URLs are configurable via the *_BASE_URL settings.
+"""
+
+from openai import OpenAI
+
+from app.config import settings
+
+
+def build_chat_client(model: str) -> tuple[OpenAI, str]:
+    """Return (client, served_model_name) for a model.
+
+    Raises RuntimeError when the selected provider's key or base URL is missing.
+    """
+    provider, served_name = _resolve_model(model)
+
+    if provider == "local":
+        if not settings.local_llm_base_url:
+            raise RuntimeError(
+                "A 'local/' model was selected but LOCAL_LLM_BASE_URL is not set."
+            )
+        client = OpenAI(
+            base_url=settings.local_llm_base_url,
+            api_key=settings.local_llm_api_key,
+        )
+        return client, served_name
+
+    if provider == "anthropic":
+        if not settings.anthropic_api_key:
+            raise RuntimeError(f"Model '{model}' requires ANTHROPIC_API_KEY, which is not set.")
+        return OpenAI(base_url=settings.anthropic_base_url, api_key=settings.anthropic_api_key), served_name
+
+    if provider == "deepseek":
+        if not settings.deepseek_api_key:
+            raise RuntimeError(f"Model '{model}' requires DEEPSEEK_API_KEY, which is not set.")
+        return OpenAI(base_url=settings.deepseek_base_url, api_key=settings.deepseek_api_key), served_name
+
+    if not settings.openai_api_key:
+        raise RuntimeError(f"Model '{model}' requires OPENAI_API_KEY, which is not set.")
+    return OpenAI(api_key=settings.openai_api_key), served_name
+
+
+_PROVIDER_PREFIXES = {
+    "local/": "local",
+    "anthropic/": "anthropic",
+    "deepseek/": "deepseek",
+    "openai/": "openai",
+}
+
+
+def _resolve_model(model: str) -> tuple[str, str]:
+    """Map a model name to (provider, served_model_name)."""
+    for prefix, provider in _PROVIDER_PREFIXES.items():
+        if model.startswith(prefix):
+            return provider, model[len(prefix):]
+    return "openai", model

--- a/services/pdf-service/app/workers/tasks.py
+++ b/services/pdf-service/app/workers/tasks.py
@@ -30,13 +30,20 @@ except Exception as e:
 
 def embedding_error_message(error: httpx.HTTPStatusError) -> str:
     """Turn an embedding-service HTTP error into a readable job error."""
-    detail = ""
+    detail_obj: object = ""
     try:
-        detail = error.response.json().get("detail", "")
+        payload = error.response.json()
+        if isinstance(payload, dict):
+            detail_obj = payload.get("detail", "")
+        else:
+            detail_obj = payload
     except Exception:
-        detail = error.response.text
+        detail_obj = error.response.text
 
-    if "out of memory" in detail.lower() or "CUDA" in detail:
+    detail = detail_obj if isinstance(detail_obj, str) else str(detail_obj)
+    detail_lower = detail.lower()
+
+    if "out of memory" in detail_lower or "cuda" in detail_lower:
         return (
             "Embedding service ran out of GPU memory. "
             "Try again shortly or process fewer files at once."

--- a/services/pdf-service/app/workers/tasks.py
+++ b/services/pdf-service/app/workers/tasks.py
@@ -28,6 +28,24 @@ except Exception as e:
     logger.warning(f"NLTK download failed: {e}")
 
 
+def embedding_error_message(error: httpx.HTTPStatusError) -> str:
+    """Turn an embedding-service HTTP error into a readable job error."""
+    detail = ""
+    try:
+        detail = error.response.json().get("detail", "")
+    except Exception:
+        detail = error.response.text
+
+    if "out of memory" in detail.lower() or "CUDA" in detail:
+        return (
+            "Embedding service ran out of GPU memory. "
+            "Try again shortly or process fewer files at once."
+        )
+    if detail:
+        return f"Embedding service error: {detail}"
+    return f"Embedding service returned HTTP {error.response.status_code}."
+
+
 def clean_text_for_postgres(text: str) -> str:
     """Remove null bytes and other problematic characters for PostgreSQL UTF-8."""
     if not text:
@@ -375,9 +393,14 @@ async def _process_pdf_async(task, file_path: str, book_name: str):
                 )
                 response.raise_for_status()
                 embeddings_data = response.json()
-            except Exception as e:
+            except httpx.HTTPStatusError as e:
                 logger.error(f"Embedding service error: {e}")
-                raise
+                raise RuntimeError(embedding_error_message(e)) from e
+            except httpx.RequestError as e:
+                logger.error(f"Embedding service unreachable: {e}")
+                raise RuntimeError(
+                    "Could not reach the embedding service. It may be down or restarting."
+                ) from e
 
             dense_embeddings = embeddings_data.get("dense_embeddings", [])
             sparse_embeddings = embeddings_data.get("sparse_embeddings", [])


### PR DESCRIPTION
## Description

Adds support for running AcademiCK against local / self-hosted LLMs (vLLM, Ollama,
LM Studio, llama.cpp, LocalAI) via their OpenAI-compatible APIs, alongside or
instead of OpenAI/Anthropic/DeepSeek. No new dependencies — the `openai` SDK
already in both services talks to any compatible endpoint.

Model routing is now driven by an explicit `provider/` name prefix (`openai/`,
`anthropic/`, `deepseek/`, `local/`; unprefixed defaults to OpenAI) instead of
guessing from bare model names, which is robust to new model names and trivial to
extend.

**Key changes**
- **api-gateway:** `build_model()` routes via `_resolve_model()` prefix map; new
  `local` branch (`OpenAIProvider` + configurable base URL/key); DeepSeek base URL
  un-hardcoded.
- **pdf-service:** new `build_chat_client()` helper applies the same prefix routing
  to chapter detection, adding Anthropic/DeepSeek/local support (cloud providers via
  their OpenAI-compatible endpoints); both PDF processors use it.
- **config:** add `LOCAL_LLM_BASE_URL` / `LOCAL_LLM_API_KEY` and provider base-URL
  overrides; per-stage model defaults now prefixed (`openai/gpt-5-nano`).
- **fail-fast:** `AVAILABLE_MODELS` prefixes are validated at startup so a
  misprefixed model errors at boot instead of silently falling through to OpenAI;
  the prefix list is shared between router and validator so they can't drift.
- **docker-compose:** injects `LOCAL_LLM_*` (default `host.docker.internal:8000/v1`)
  with `host-gateway` `extra_hosts` on api-gateway, pdf-service, and pdf-worker.
- **docs:** new `docs/local-llms.md` guide; README and USAGE updated for the prefix
  convention and new vars.

> Note: the query-enhancement and curation stages use Pydantic AI structured
> outputs (tool calls), so a local model used for those stages must support tool
> calling. The main answer model and PDF detection are plain text and don't.

## Type of Change

- New feature
- Documentation update

## How Has This Been Tested?

- All services start and pass health checks (`docker compose ps`)
- Verified prefix routing maps each provider correctly and strips the prefix
  (including nested names like `local/meta-llama/Llama-3.1-8B-Instruct`)
- `build_chat_client()` exercised live: each prefix produces the correct base URL
  and served model name
- Confirmed the `AVAILABLE_MODELS` startup validation rejects unprefixed values and
  accepts prefixed ones
- Verified no existing functionality is broken (cloud OpenAI/Anthropic/DeepSeek
  paths unchanged)

## Checklist

- My code follows the existing code style of this project
- I have not committed any secrets or API keys
- I have updated the documentation if needed
- My changes don't introduce new warnings or errors in the logs
